### PR TITLE
Fix the behavior of `patch()` when conflicts are happen

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -198,7 +198,6 @@ export async function joinPageRoom(
             parentId = page.commitId;
             created = page.persistent;
             lines = page.lines;
-            break;
           } catch (e: unknown) {
             throw e;
           }


### PR DESCRIPTION
[⬜patchのリトライ時はlinesも更新する](https://scrapbox.io/takker/⬜patchのリトライ時はlinesも更新する)