### PR TITLE
:recycle: Replace implement of getPage()

### DIFF
--- a/deps/scrapbox-std.ts
+++ b/deps/scrapbox-std.ts
@@ -1,2 +1,3 @@
 export * from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.5.0/rest/project.ts";
 export * from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.5.0/rest/profile.ts";
+export * from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.5.0/rest/pages.ts";


### PR DESCRIPTION
close [⬜getPage()をscrapbox-userscript-stdのに置き換える](https://scrapbox.io/takker/⬜getPage()をscrapbox-userscript-stdのに置き換える)